### PR TITLE
Excluir exemplo 2 em <sig-block>

### DIFF
--- a/docs/source/tagset.rst
+++ b/docs/source/tagset.rst
@@ -4425,8 +4425,6 @@ Os valores que podem ser utilizados para o atributo ``@publication-type`` são:
 
   * Nunca manter uma informação toda com formatação <italic>, <bold>, etc,
     dentro de alguma tag;
-  * Todas as referências devem conter informação de fonte principal
-    :ref:`elemento-source`;
   * Evitar pontuação dentro da marcação em :ref:`elemento-element-citation`
     (ponto final, vírgula etc);
   * Todas as informaçoes de uma referência devem ser marcadas, caso não exista

--- a/docs/source/tagset.rst
+++ b/docs/source/tagset.rst
@@ -4187,20 +4187,7 @@ Exemplo 1:
     ...
 
 
-**Exemplo 2:**
-
-.. code-block:: xml
- 
-    <sig-block>
-        <sig>
-            <bold>Harry Weasley</bold>
-            <italic>Editor Chefe<italic>
-            Profeta Diário
-        </sig>
-    </sig-block>
- 
-
-.. note:: Para arquivos que apresentam apenas uma assinatura ao final do documento, é preciso repetir os nomes que constam na assinatura em front\contrib e marcá-los como autores.
+.. note:: Para arquivos que apresentam apenas uma assinatura ao final do documento, é preciso repetir os nomes que constam na assinatura em front/contrib e marcá-los como autores.
 
  
 .. _elemento-back:

--- a/docs/source/tagset.rst
+++ b/docs/source/tagset.rst
@@ -4169,7 +4169,7 @@ conter a tag ``<sig>``. É possível formatar o texto do bloco de assinatura
 com negrito ``<bold>`` ou itálico ``<italic>``. Para as quebras de linhas 
 deve-se usar a tag ``<break/>`` como mostram os exemplos a seguir:
 
-Exemplo 1:
+Exemplo:
  
 .. code-block:: xml
  


### PR DESCRIPTION
Foi excluído o segundo exemplo em `<sig-block>` por entendermos que eram duas maneiras diferentes para representar a mesma coisa conforme ticket aberto #80 por @RPostalli . Além disso alterou-se a nota do mesmo elemento. Havia um erro que juntava duas palavras.