### PR TITLE
Inclusão de nota sobre 'country' em translation

### DIFF
--- a/docs/source/tagset/elemento-country.rst
+++ b/docs/source/tagset/elemento-country.rst
@@ -35,5 +35,6 @@ Exemplo:
     </aff>
     ...
 
-.. note:: O uso desse elemento, ``<country>``, é obrigatório
+.. note:: Arquivos do tipo "translation" não devem apresentar o elemento ``<country>`` em ``<aff>``.
+O detalhamento da afiliação, no caso de tradução, é feito apenas 1 vez no arquivo de idioma principal.
 

--- a/docs/source/tagset/elemento-related-article.rst
+++ b/docs/source/tagset/elemento-related-article.rst
@@ -33,6 +33,18 @@ Os valores possíveis para o atributo ``@related-article-type`` são:
 +------------------------+-------------------------------------------+
 
 
+Para Errata o elemento :ref:`elemento-related-article` obrigatoriamente deve apresentar os 
+seguintes atributos: ``@related-article-type``; ``@id``; ``@xlink:href`` e 
+``@ext-link-type``. 
+
+Os valores possíveis para o atributo ``@ext-link-type``:
+
+
+* doi
+* scielo-pid
+* scielo-aid
+
+
 
 Referências
 ===========


### PR DESCRIPTION
Inclusão de nota sobre ```<country>``` em arquivos de tradução.