### PR TITLE
Inclusão do elemento <sec> no 'Aparece em' de <xref>. Fixes # 367

### DIFF
--- a/docs/source/tagset/elemento-xref.rst
+++ b/docs/source/tagset/elemento-xref.rst
@@ -12,6 +12,7 @@ Aparece em:
   ``<td>``,
   ``<th>``,
   :ref:`elemento-trans-title`,
+  :ref:`elemento-sec`
   ``<verse-line>``.
   
 Atributos obrigatórios:


### PR DESCRIPTION
Inclusão do elemento ```<sec>``` no 'Aparece em' de ```<xref>```.