### PR TITLE
Permitir elemento <label> em <ref-lits> e inserção de exemplos. Fix #372

### DIFF
--- a/docs/source/tagset/elemento-ref-list.rst
+++ b/docs/source/tagset/elemento-ref-list.rst
@@ -13,9 +13,18 @@ Ocorre:
 
 Representa o conjunto de referências bibliográficas de um artigo e deve conter, obrigatoriamente, o elemento :ref:`elemento-ref`, que por sua vez contém :ref:`elemento-mixed-citation` e :ref:`elemento-element-citation`.
 
-Em ``<ref-list>`` deve ser inserido um rótulo sob ``<title>`` identificando aquela seção de texto.
+Em ``<ref-list>`` deve ser inserido um rótulo sob ``<title>`` identificando aquela seção de texto. O elemento ``<ref-list>`` permite também o elemento ``<label>`` para identificação de texto adicional ou subtítulo.
 
-Exemplo:
+
+Exemplos:
+
+* :ref:`elemento-ref-list-exemplo-1`
+* :ref:`elemento-ref-list-exemplo-2`
+
+
+.. _elemento-ref-list-exemplo-1:
+
+Exemplo de ``<ref-list>`` simples:
 
 .. code-block:: xml
 
@@ -28,5 +37,29 @@ Exemplo:
         ...
     </ref-list>
     ...
+
+
+.. _elemento-ref-list-exemplo-2:
+
+Exemplo de ``<ref-list>`` com 2 títulos:
+----------------------------------------
+
+.. code-bloc:: xml
+
+    ...
+    <ref-list>
+        <title>Referências Bibliográficas</title>
+        <label>Fontes primárias</label>
+        <ref id="B1">
+            ...
+        </ref>
+        ...
+    </ref-list>
+    ...
+
+
+.. note:: A ordem dos elementos é importante. O elemento ``<title>`` deve ser inserido antes do elemento ``<label>``.
+
+
 
 .. {"reviewed_on": "20160628", "by": "gandhalf_thewhite@hotmail.com"}


### PR DESCRIPTION
Permitir elemento ```<label>``` em ```<ref-lits>``` e inserção de exemplos