### PR TITLE
inclusao de elemento no 'Aparece em' de <ext-link>. Fixes #333

### DIFF
--- a/docs/source/tagset/elemento-ext-link.rst
+++ b/docs/source/tagset/elemento-ext-link.rst
@@ -5,9 +5,10 @@
 
 Aparece em:
 
-  :ref:`elemento-p`
-  :ref:`elemento-element-citation`
   :ref:`elemento-comment`
+  :ref:`elemento-element-citation`
+  :ref:`elemento-p`
+  :ref:`elemento-product`  
 
 Atributos obrigatórios:
 


### PR DESCRIPTION
inclusao de elemento no 'Aparece em' de ```<ext-link>```.