### PR TITLE
Correção em texto sobre <inline-graphic>. Fix #359

### DIFF
--- a/docs/source/tagset/elemento-inline-graphic.rst
+++ b/docs/source/tagset/elemento-inline-graphic.rst
@@ -17,7 +17,7 @@ Ocorre:
   Zero ou mais vezes
 
 
-Usado para identificar equações incluídas como imagem que estejam posicionadas em linha, ou seja, ancoradas em um parágrafo.
+Usado para identificar ícones inseridos como imagem que estejam posicionado em linha, ou seja, ancorados em um parágrafo.
 
 O guia :ref:`sugestao-atribuicao-id` descreve o modo de composição do atributo ``@id``, caso este seja utilizado.
 

--- a/docs/source/tagset/sugestao-atribuicao-id.rst
+++ b/docs/source/tagset/sugestao-atribuicao-id.rst
@@ -28,7 +28,7 @@ Para a composição do ``@id``, deve-se combinar o prefixo do tipo de elemento c
 +------------------------+---------------------------+---------+---------------------+
 | glossary               | Glossário                 | gl      | gl1, gl2, ...       |
 +------------------------+---------------------------+---------+---------------------+
-| inline-graphic         | Imagens em linha          | i       | i1, i2, ...         |
+| inline-graphic         | Ícones em linha           | i       | i1, i2, ...         |
 +------------------------+---------------------------+---------+---------------------+
 | inline-supplementary-  | Material suplementar em   | suppl   | suppl1, suppl3, ... |
 | material               | linha                     |         |                     |


### PR DESCRIPTION
Correção em texto sobre ```<inline-graphic>```. O elemento identifica ícones que estão como imagem em linha e não *equações*.