### PR TITLE
Exclusão de 'dois pontos' em 'Número especial'

### DIFF
--- a/docs/source/narr/regra-nomeacao.rst
+++ b/docs/source/narr/regra-nomeacao.rst
@@ -229,8 +229,8 @@ Publicação Contínua
 
 .. _elemento-nomeia-arquivo-exemplo-5:
 
-Para Número em aberto:
-^^^^^^^^^^^^^^^^^^^^^^
+Para Número em aberto
+^^^^^^^^^^^^^^^^^^^^^
 
 Regra:
 


### PR DESCRIPTION
Exclusão de 'dois pontos' em 'Número especial'