### PR TITLE
Correção nos tópicos do guia SciELO Publishing Schema 1.5

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -112,7 +112,7 @@ Glossário
 
 
    MathML
-     Acrónimo de *Mathematical Markup Language* - (Linguagem de Marcação Matemática). Especificação de baixo nível para conteúdo matemático e científico na Internet e mídias similares. Criado e mantido pelo *Math Working Group* (Grupo de trabalho de matemática) do :term:`W3C` (*World Wide Web Consortium), tornou-se padrão regulamentado pela :term:`ISO` por meio da norma *ISO/IEC 40314:2015*. Para maiores informações ver `W3C Math Home <https://www.w3.org/Math/>`_.
+     Acrónimo de *Mathematical Markup Language* - (Linguagem de Marcação Matemática). Especificação de baixo nível para conteúdo matemático e científico na Internet e mídias similares. Criado e mantido pelo *Math Working Group* (Grupo de trabalho de matemática) do :term:`W3C` (*World Wide Web Consortium*), tornou-se padrão regulamentado pela :term:`ISO` por meio da norma *ISO/IEC 40314:2015*. Para maiores informações ver `W3C Math Home <https://www.w3.org/Math/>`_.
 
 
    Metodologia SciELO

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -167,7 +167,6 @@ Esta lista compreende apenas os elementos *XML* do :term:`Estilo SciELO PS`. A l
 =================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`
 
 .. {"reviewed_on": "20160729", "by": "gandhalf_thewhite@hotmail.com"}

--- a/docs/source/narr/regra-nomeacao.rst
+++ b/docs/source/narr/regra-nomeacao.rst
@@ -327,7 +327,7 @@ Regra para Imagens traduzidas
 
 Regra:
 
-    ``ISSN``-``acrônimo``-``volume``-``número``-``paginação``-``nomedaimagem``-``idioma``.``extensãodaimagem``
+    ``ISSN``-``acrônimo``-``volume``-``número``-``paginação``-``nomedaimagem``-``idioma.extensãodaimagem``
 
 Exemplo:
 

--- a/docs/source/narr/regra-nomeacao.rst
+++ b/docs/source/narr/regra-nomeacao.rst
@@ -311,7 +311,7 @@ Para publicação de Número Especial
 
 Regra:
     
-    ``ISSN``-``acrônimo``-``volume``-``nº especial``-``paginação``-``nomedaimagem.extensãodaimagem``
+    ``ISSN``-``acrônimo``-``volume``-``nº especial``-``paginação``-``nomedaimagem.extensãodaimagem`` 
 
 Exemplo:
 
@@ -571,7 +571,7 @@ Casos Especiais
 +-----------------------+----------------------------------------------------------------------------+--------------------------------------------+
 
 
-.. note:: Cada item deve ser separado por um hífen e deve, obrigatoriamente, manter visível a extensão da imagem após o "ponto", optando, preferencialmente, por imagens em formato *tif*.
+.. note:: Cada item deve ser separado por um hífen e deve, obrigatoriamente, manter visível a extensão da imagem após o "ponto".
 
 
 .. important::

--- a/docs/source/tagset/elemento-contrib-group.rst
+++ b/docs/source/tagset/elemento-contrib-group.rst
@@ -6,6 +6,7 @@
 Aparece em:
 
   :ref:`elemento-article-meta`
+  :ref:`elemento-front-stub`
 
 Ocorre:
 
@@ -17,7 +18,6 @@ Os principais elementos de ``<contrib-group>`` são:
 
 * :ref:`elemento-aff`;
 * :ref:`elemento-contrib`;
-* :ref:`elemento-front-stub`;
 * :ref:`elemento-role`;
 * :ref:`elemento-xref`;
 

--- a/docs/source/tagset/elemento-disp-formula.rst
+++ b/docs/source/tagset/elemento-disp-formula.rst
@@ -39,7 +39,7 @@ Equação codificada:
     <!-- codificar: σˆ2 -->
 
     ...
-    <xref ref-type="disp-formula" rid="e07">Equation 3</xref>
+    <xref ref-type="disp-formula" rid="e03">Equation 3</xref>
     <disp-formula id="e03">
       <mml:math display="block">
         <mml:mrow>

--- a/docs/source/tagset/elemento-fig.rst
+++ b/docs/source/tagset/elemento-fig.rst
@@ -65,7 +65,7 @@ As imagens podem ou não ter legendas. Para imagens sem legenda é necessário m
 Exemplo de Figura com label e caption:
 --------------------------------------
 
-Para figuras com legenda a marcação deve ocorrer para toda a informação da imagem, inclusive sua descrição com o elemento ``<fig>``. Dentro de ``<fig>`` serão identificados o rótulo da figura (:ref:`elemento-label`) e a legenda (:ref:`elemento-caption`) com o título da figura em ``title``.
+Para figuras com legenda a marcação deve ocorrer para toda a informação da imagem, inclusive sua descrição com o elemento ``<fig>``. Dentro de ``<fig>`` serão identificados o rótulo da figura (:ref:`elemento-label`) e a legenda (:ref:`elemento-caption`) com o título da figura em :ref:`elemento-title`.
 
 .. code-block:: xml
 
@@ -140,7 +140,7 @@ Exemplo completo de Figura com atributo ``@id``:
 Legendas traduzidas
 -------------------
 
-Figuras que apresentam legendas traduzidas (com mais de um :ref:`elemento-label` e :ref:`elemento-captiob`), devem ser identificadas com o elemento ``<fig-group>``, o qual deve conter os elementos ``<fig>`` para cada idioma utilizando o atributo ``@xml:lang``.
+Figuras que apresentam legendas traduzidas (com mais de um :ref:`elemento-label` e :ref:`elemento-caption`), devem ser identificadas com o elemento ``<fig-group>``, o qual deve conter os elementos ``<fig>`` para cada idioma utilizando o atributo ``@xml:lang``.
 
 
 .. _elemento-fig-exemplo-6:

--- a/docs/source/tagset/elemento-fn.rst
+++ b/docs/source/tagset/elemento-fn.rst
@@ -61,8 +61,6 @@ Os valores possíveis para ``@fn-type`` são:
 |                           | tipo de nota em :ref:`elemento-fn-group` em      |
 |                           | :ref:`elemento-back`                             |
 +---------------------------+--------------------------------------------------+
-| presented-at              | Trabalho apresentado em conferência, colóquio etc|
-+---------------------------+--------------------------------------------------+
 | presented-by              | Informação de trabalho apresentado pelo autor    |
 +---------------------------+--------------------------------------------------+
 

--- a/docs/source/tagset/elemento-front.rst
+++ b/docs/source/tagset/elemento-front.rst
@@ -12,7 +12,7 @@ Ocorre:
   Uma vez
 
 
-Neste elemento devem ser identificados <journal-meta> e <article-meta>.
+Neste elemento devem ser identificados :ref:`elemento-journal-meta` e :ref:`elemento-article-meta`.
 
 Exemplo:
 

--- a/docs/source/tagset/elemento-funding-group.rst
+++ b/docs/source/tagset/elemento-funding-group.rst
@@ -18,7 +18,8 @@ Usado somente quando há um número de contrato explicitado no artigo. As inform
 Exemplo:
 
 .. code-block:: xml
-	...
+
+   ...
 	<funding-group>
 		<award-group>
 			<funding-source>CNPQ</funding-source>

--- a/docs/source/tagset/elemento-history.rst
+++ b/docs/source/tagset/elemento-history.rst
@@ -25,6 +25,11 @@ Exemplo:
              <month>10</month>
              <year>2014</year>
         </date>
+        <date date-type="rev-recd">
+             <day>06</day>
+             <month>11</month>
+             <year>2013</year>
+        </date>
         <date date-type="accepted">
              <day>14</day>
              <month>07</month>

--- a/docs/source/tagset/elemento-issue.rst
+++ b/docs/source/tagset/elemento-issue.rst
@@ -19,6 +19,7 @@ Exemplos:
 
   * :ref:`elemento-issue-exemplo-1`
   * :ref:`elemento-issue-exemplo-2`
+  * :ref:`elemento-issue-exemplo-3`
 
 
 
@@ -62,6 +63,25 @@ Exemplo de Fascículo Especial em ``<front>``:
         </article-meta>
         ...
     </front>
+    ...
+
+
+
+.. _elemento-issue-exemplo-3:
+
+Exemplo de ``<issue>`` em ``<element-citation>``:
+-------------------------------------------------
+
+.. code-block:: xml
+
+    ...
+    <ref id="B01">
+        ...
+        <source>text text text</source>
+        <volume>10</volume>
+        <issue>5</issue>
+        ...
+    </ref>
     ...
 
 

--- a/docs/source/tagset/elemento-subj-group.rst
+++ b/docs/source/tagset/elemento-subj-group.rst
@@ -33,7 +33,7 @@ Com o elemento ``<subj-group>`` é possível identificar :ref:`subsecao-exemplo-
 .. _elemento-subjgroup-exemplo-1:
 
 Exemplo de ``<subj-group>`` temática:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------
 
 .. code-block:: xml
 
@@ -49,7 +49,7 @@ Exemplo de ``<subj-group>`` temática:
 .. _elemento-subjgroup-exemplo-2:
 
 Exemplo de ``<subj-group>`` por tipo de documento:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------------
 
 .. code-block:: xml
 
@@ -65,7 +65,7 @@ Exemplo de ``<subj-group>`` por tipo de documento:
 .. _elemento-subjgroup-exemplo-3:
 
 Exemplo de ``<subj-group>`` para ``<ahead-of-print>``:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------------------
 
 .. code-block:: xml
 
@@ -86,7 +86,7 @@ Exemplo de ``<subj-group>`` para ``<ahead-of-print>``:
 .. _subsecao-exemplo-1:
 
 Subseções em documento
-======================
+~~~~~~~~~~~~~~~~~~~~~~
 
 Artigos que apresentam subseções devem ser identificados no :term:`documento` por meio do elemento :ref:`elemento-subj-group`.
 


### PR DESCRIPTION
Correção nos tópicos:
* glossary
* index
* regra de nomeação
* contrib-group
* disp-formula
* fig
* fn
* fpage
* front-stub
* front
* funding-group
* history
* issue

