### PR TITLE
Correção em valor de ext-link-type de Ensaio Clínico

### DIFF
--- a/docs/source/narr/ensaio-clinico.rst
+++ b/docs/source/narr/ensaio-clinico.rst
@@ -12,11 +12,11 @@ Exemplo:
 .. code-block:: xml
 
    ...
-   <p>Número de registro clínico:<ext-link ext-link-type="ClinicalTrial" xlink:href="https://clinicaltrials.gov/ct2/show/NCT00981734">NCT00981734</ext-link></p>
+   <p>Número de registro clínico:<ext-link ext-link-type="clinical-trial" xlink:href="https://clinicaltrials.gov/ct2/show/NCT00981734">NCT00981734</ext-link></p>
    ...
 
 
-Para identificação de um Ensaio Clínico, o elemento :ref:`elemento-ext-link` deve apresentar o valor ``ClinicalTrial`` no atributo ``@ext-link-type`` e ter preenchida a URL do registro de Ensaio Clínico no atributo ``@xlink:href``.
+Para identificação de um Ensaio Clínico, o elemento :ref:`elemento-ext-link` deve apresentar o valor ``clinical-trial`` no atributo ``@ext-link-type`` e ter preenchida a URL do registro de Ensaio Clínico no atributo ``@xlink:href``.
 
 Informações adicionais encontram-se disponíveis nos sites abaixo identificados:
 

--- a/docs/source/tagset/elemento-ext-link.rst
+++ b/docs/source/tagset/elemento-ext-link.rst
@@ -27,7 +27,7 @@ Especifica referências a recursos disponíveis na internet. As únicas restriç
 Os valores possíveis para o ``@ext-link-type`` são:
 
 * uri
-* ClinicalTrial
+* clinical-trial
 
 
 Exemplo URL:
@@ -44,7 +44,7 @@ Exemplo Ensaio Clínico:
 .. code-block:: xml
 
   ...
-    <ext-link ext-link-type="ClinicalTrial" xlink:href="https://clinicaltrials.gov/ct2/show/NCT01995279?term=NCT01995279">NCT01995279</ext-link>
+    <ext-link ext-link-type="clinical-trial" xlink:href="https://clinicaltrials.gov/ct2/show/NCT01995279?term=NCT01995279">NCT01995279</ext-link>
   ...
     
 


### PR DESCRIPTION
Em Ensaio Clínico o valor de ``@ext-link-type"" foi alterado para "clinical-trial".
Relacionado ao ticket #242 .