### PR TITLE
Exclui lista de licenças Creative Commons de regras SciELO Brasil

### DIFF
--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -28,3 +28,69 @@ Exemplo:
 	<article-id pub-id-type="doi">10.1590/0100-29452016221</article-id>
 	...
 	
+.. _elemento-scibrasil-license:
+
+<license>
+^^^^^^^^^
+
+De acordo com a política de acesso aberto adotada por SciELO Brasil, serão aceitas apenas as licenças `Creative Commons <http://creativecommons.org/>`_  listadas na tabela abaixo:
+
+
++----------------------------------------------------------+-------------------------+
+| Valor                                                    | Descrição               |
++==========================================================+=========================+
+| http://creativecommons.org/licenses/by/4.0/              | CC-BY versão 4.0        |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by/sa/4.0/           | CC-BY-SA versão 4.0     |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by/3.0/              | CC-BY versão 3.0        |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by/sa/3.0/           | CC-BY-SA versão 3.0     |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by-nc/4.0/           | CC-BY-NC versão 4.0     |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by-nc/sa/4.0/        | CC-BY-NC-SA versão 4.0  |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by-nc/3.0/           | CC-BY-NC versão 3.0     |
++----------------------------------------------------------+-------------------------+
+| http://creativecommons.org/licenses/by-nc/sa/3.0/        | CC-BY-NC-SA versão 3.0  |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by-nc-nd/3.0/       | CC-BY-NC-ND versão 3.0  |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by-nc-nd/4.0/       | CC-BY-NC-ND versão 4.0  |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by/3.0/igo/         | BY/IGO versão 3.0       |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by-nc/3.0/igo/      | BY-NC/IGO versão 3.0    |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by/sa/3.0/igo/      | BY/IGO/SA versão 3.0    |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by-nc/sa/3.0/igo/   | BY-NC/IGO/SA versão 3.0 |
++----------------------------------------------------------+-------------------------+
+| https://creativecommons.org/licenses/by-nc-nd/3.0/igo/   | BY-NC-ND/IGO versão 3.0 |
++----------------------------------------------------------+-------------------------+
+
+
+A URL da licença deve ser inserida como valor do atributo ``@xlink:href`` de :ref:`elemento-license`. Exemplo:
+
+
+.. code-block:: xml
+
+	...
+    <article-meta>
+        ...
+        <permissions>
+            ...
+            <license license-type="open-access"
+                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                     xml:lang="en">
+                <license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</license-p>
+            </license>
+        </permissions>
+      	...
+    </article-meta>
+    ...
+
+
+
+.. note:: Considera-se a lista de licenças permitidas apenas para :ref:`elemento-article-meta`.

--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -1,4 +1,4 @@
-.. _scielo-brasil:
+﻿.. _scielo-brasil:
 
 Regras Específicas para SciELO Brasil
 =====================================
@@ -28,59 +28,3 @@ Exemplo:
 	<article-id pub-id-type="doi">10.1590/0100-29452016221</article-id>
 	...
 	
-
-
-.. _elemento-scibrasil-license:
-
-<license>
-^^^^^^^^^
-
-De acordo com a política de acesso aberto adotada por SciELO Brasil, serão aceitas apenas as licenças `Creative Commons <http://creativecommons.org/>`_  listadas na tabela abaixo:
-
-
-+--------------------------------------------------------+-------------------------+
-| Valor                                                  | Descrição               |
-+========================================================+=========================+
-| http://creativecommons.org/licenses/by/4.0/            | CC-BY versão 4.0        |
-+--------------------------------------------------------+-------------------------+
-| http://creativecommons.org/licenses/by/3.0/            | CC-BY versão 3.0        |
-+--------------------------------------------------------+-------------------------+
-| http://creativecommons.org/licenses/by-nc/4.0/         | CC-BY-NC versão 4.0     |
-+--------------------------------------------------------+-------------------------+
-| http://creativecommons.org/licenses/by-nc/3.0/         | CC-BY-NC versão 3.0     |
-+--------------------------------------------------------+-------------------------+
-| https://creativecommons.org/licenses/by-nc-nd/3.0/     | CC-BY-NC-ND versão 3.0  |
-+--------------------------------------------------------+-------------------------+
-| https://creativecommons.org/licenses/by-nc-nd/4.0/     | CC-BY-NC-ND versão 4.0  |
-+--------------------------------------------------------+-------------------------+
-| https://creativecommons.org/licenses/by/3.0/igo/       | BY/IGO versão 3.0       |
-+--------------------------------------------------------+-------------------------+
-| https://creativecommons.org/licenses/by-nc/3.0/igo/    | BY-NC/IGO versão 3.0    |
-+--------------------------------------------------------+-------------------------+
-| https://creativecommons.org/licenses/by-nc-nd/3.0/igo/ | BY-NC-ND/IGO versão 3.0 |
-+--------------------------------------------------------+-------------------------+
-
-
-A URL da licença deve ser inserida como valor do atributo ``@xlink:href`` de :ref:`elemento-license`. Exemplo:
-
-
-.. code-block:: xml
-
-	...
-    <article-meta>
-        ...
-        <permissions>
-            ...
-            <license license-type="open-access"
-                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
-                     xml:lang="en">
-                <license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</license-p>
-            </license>
-        </permissions>
-      	...
-    </article-meta>
-    ...
-
-
-
-.. note:: Considera-se a lista de licenças permitidas apenas para :ref:`elemento-article-meta`.


### PR DESCRIPTION
Fixes #198 excluída restrição de licenças CC de regras SciELO Brasil uma vez que é permitida qualquer licença Creative Commons.