### PR TITLE
Inserir table-wrap-foot em attrib

### DIFF
--- a/docs/source/tagset/elemento-attrib.rst
+++ b/docs/source/tagset/elemento-attrib.rst
@@ -1,4 +1,4 @@
-.. _elemento-attrib:
+﻿.. _elemento-attrib:
 
 <attrib>
 ========
@@ -12,6 +12,7 @@ Aparece em:
   :ref:`elemento-supplementary-material`
   :ref:`elemento-table-wrap`
   :ref:`elemento-verse-group`
+  :ref:`elemento-table-wrap-foot`
 
 Ocorre:
 


### PR DESCRIPTION
Fixes #480 inclui elemento table-wrap-foot em "aparece em" do elemento attrib.