### PR TITLE
Inclui elemento <alternatives>

### DIFF
--- a/docs/source/tagset/elemento-alternatives.txt
+++ b/docs/source/tagset/elemento-alternatives.txt
@@ -1,0 +1,119 @@
+﻿.. _elemento-alternatives:
+
+<alternatives>
+==============
+
+Aparece em:
+
+  :ref:`elemento-table-wrap`
+  :ref:`elemento-disp-formula`
+  :ref:`elemento-inline-formula`
+
+Ocorre:
+
+  Zero ou mais vezes
+
+Elemento usado para armazenar um grupo de alternativas para processamento de um determinado conjunto informacional em versões logicamente equivalentes (substituto), como por exemplo, uma tabela codificada e sua imagem equivalente. 
+
+.. note:: Em <alternatives> as imagens em <graphic> devem, obrigatoriamente, possuir a extensão .svg.
+
+Exemplos:
+
+  * :ref:`elemento-table-exemplo-1`
+  * :ref:`elemento-disp-formula-exemplo-2`
+  * :ref:`elemento-inline-formula-exemplo-3`
+
+.. _elemento-table-exemplo-1:
+
+Exemplo de <alternatives> em <table-wrap>:
+------------------------------------------
+
+.. code-block:: xml
+    ...
+    <table-wrap id="t1">
+<label>Table 1</label>
+        <caption>
+            <title>Chemical characterization of the oxides of the tailing</title>
+        </caption>
+        <alternatives>
+        <graphic xlink:href="nomedaimagemdatabela.svg"/>
+        <table frame="hsides" rules="groups">
+            <thead>
+                <tr>
+                    <th>Variável</th>
+                    <th>Resultados (N=880)</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td align="center">Gênero</td>
+                    <td align="center"/>
+                </tr>
+                <tr>
+                    <td align="center">Masculino</td>
+                    <td align="center">411 (46,7)</td>
+                </tr>
+                <tr>
+                    <td align="center">Feminino</td>
+                    <td align="center">469 (53,3)</td>
+                </tr>
+            </tbody>
+        </table>
+        </alternatives>
+    </table-wrap>
+    ...
+
+.. _elemento-disp-formula-exemplo-2:
+
+Exemplo de <alternatives> em <disp-formula>:
+--------------------------------------------
+
+.. code-block:: xml
+    ...
+<disp-formula id="e10">
+                        <label>(1)</label>
+                        <alternatives>
+                            <tex-math id="tx1">
+                                documentclass {article}
+                                \usepackage{wasysym}
+                                \usepackage[substack]{amsmath}
+                                \usepackage{amsfonts}
+                                \usepackage{amssymb}
+                                \usepackage{amsbsy}
+                                \usepackage[mathscr]{eucal}
+                                \usepackage{mathrsfs}                           
+                                \usepackage{pmc}
+                                    \usepackage[Euler]{upgreek}
+                                  \pagestyle{empty}
+                                    \oddsidemargin -1.0in
+                                    \begin{document}
+                                    \[E_it=α_i+Z_it γ+W_it δ+C_it θ+∑_i^n EFind_i+∑_t^n EFtemp_t+ ε_it
+                                    \]
+                                    \end{document}
+                            </tex-math>
+                            <graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg"/>
+                        </alternatives>
+                    </disp-formula>
+
+.. _elemento-inline-formula-exemplo-3:
+
+Exemplo de <alternatives> em <disp-formula>:
+--------------------------------------------
+.. code-block:: xml
+    ...
+<inline-formula>
+<alternatives>
+    <mml:math id="e03">
+        <mml:mrow>
+            <mml:msup>
+                <mml:mover accent="true">
+                    <mml:mi>σ</mml:mi>
+                    <mml:mo>ˆ</mml:mo>
+                </mml:mover>
+                <mml:mn>2</mml:mn>
+            </mml:msup>
+        </mml:mrow>
+    </mml:math>
+<graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg"/>
+</alternatives>
+</inline-formula>

--- a/docs/source/tagset/elemento-disp-formula.rst
+++ b/docs/source/tagset/elemento-disp-formula.rst
@@ -1,4 +1,4 @@
-.. _elemento-disp-formula:
+﻿.. _elemento-disp-formula:
 
 <disp-formula>
 ==============
@@ -21,18 +21,19 @@ Ocorre:
   Zero ou mais vezes
 
 
-Identifica equações em parágrafos do texto, preferencialmente codificadas. Podem, excepcionalmente, ser apresentadas como imagem, devendo incluir o nome do arquivo de imagem no elemento ``<graphic>``. O atributo ``@id`` é mandatório.
-
+Identifica equações, expressões ou fórmulas matemáticas exibidas como um bloco dentro de um fluxo narrativo. Pode ser codificada usando MathML, TeX ou LaTeX.
 
 Exemplos:
 
-  * :ref:`elemento-eqcod-exemplo-1`
-  * :ref:`elemento-eqcod-exemplo-2`
+  * :ref:`elemento-dispmath-exemplo-1`
+  * :ref:`elemento-displatex-exemplo-2`
 
-.. _elemento-eqcod-exemplo-1:
 
-Equação codificada:
--------------------
+.. _elemento-dispmath-exemplo-1:
+
+
+Equação codificada em MathML:
+-----------------------------
 
 .. code-block:: xml
 
@@ -67,21 +68,41 @@ Equação codificada:
     </disp-formula>
     ...
 
-.. _elemento-eqcod-exemplo-2:
+.. _elemento-displatex-exemplo-2:
 
-Equação em imagem:
-------------------
+
+Equação codificada em LaTeX:
+----------------------------
 
 .. code-block:: xml
 
-    ...
-    <p>The Eh measurements were recalculated to the standard hydrogen potential (Standard Hydrogen Electrode - SHE), using the following <xref ref-type="disp-formula" rid="e01">equation 1</xref>(in mV):</p>
-    <disp-formula id="e01">
-        <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>
-    </disp-formula>
-    ...
+...
 
-
+<p>... Selected as described for Acc-29
+<disp-formula>
+<tex-math id="M1"><![CDATA[\documentclass[12pt]{minimal}
+\usepackage{wasysym}
+\usepackage[substack]{amsmath}
+\usepackage{amsfonts}
+\usepackage{amssymb}
+\usepackage{amsbsy}
+\usepackage[mathscr]{eucal}
+\usepackage{mathrsfs}
+\DeclareFontFamily{T1}{linotext}{}
+\DeclareFontShape{T1}{linotext}{m}{n} { &#x003C;-&#x003E; linotext }{}
+\DeclareSymbolFont{linotext}{T1}{linotext}{m}{n}
+\DeclareSymbolFontAlphabet{\mathLINOTEXT}{linotext}
+\begin{document}
+$$
+{\mathrm{Acc/Acc:\hspace{.5em}}}\frac{{\mathit{ade2-202}}}{{\mathit{ADE2}}}\
+hspace{.5em}\frac{{\mathit{ura3-59}}}{{\mathit{ura3-59}}}\hspace{.5em}\frac{{\
+mathit{ADE1}}}{{\mathit{adel-201}}}\hspace{.5em}\frac{{\mathit{ter1-Acc}}}{{\
+mathit{ter1-Acc}}}\hspace{.5em}\frac{{\mathit{MATa}}}{{\mathit{MAT{\alpha}}}}
+$$
+\end{document}]]>
+</tex-math>
+</disp-formula> TER1/ter1-Acc: Acc-29 crossed with ...</p>
+...
 
 .. note:: Equações que não estejam identificadas sob ``<app-group>`` devem ser inseridas obrigatoriamente após a primeira chamada no texto. Para material suplementar, analisar e identificar caso a caso.
 

--- a/docs/source/tagset/elemento-table.rst
+++ b/docs/source/tagset/elemento-table.rst
@@ -1,4 +1,4 @@
-.. _elemento-table:
+﻿.. _elemento-table:
 
 <table>
 =======
@@ -92,16 +92,7 @@ Legenda Traduzida
 
 Tabelas com legendas traduzidas, com mais de um rótulo (``<label>``) e legenda (``<caption>``), devem ser identificadas pelo elemento ``<table-wrap-group>``, o qual deve conter os elementos ``<table-wrap>`` para cada idioma.
 
-Exemplos:
-
-  * :ref:`elemento-tablegend-exemplo-1`
-  * :ref:`elemento-tablegend-exemplo-2`
-
-
-.. _elemento-tablegend-exemplo-1:
-
-Exemplo de tabela codificada:
------------------------------
+Exemplo de tabela codificada com legenda traduzida:
 
 .. code-block:: xml
 
@@ -140,32 +131,6 @@ Exemplo de tabela codificada:
                     </tr>
                 </tbody>
             </table>
-        </table-wrap>
-    </table-wrap-group>
-    ...
-
-
-.. _elemento-tablegend-exemplo-2:
-
-Exemplo de tabela como imagem:
-------------------------------
-
-.. code-block:: xml
-
-    ...
-    <table-wrap-group id="t03">
-        <table-wrap xml:lang="pt">
-            <label>Tabela 3</label>
-            <caption>
-                <title>Análise multivariada dos fatores de risco associados à readmissão - modelo 2</title>
-            </caption>
-        </table-wrap>
-        <table-wrap id="en">
-            <label>Table 3</label>
-            <caption>
-                <title>Multivariate analysis of risk factors associated with readmission - Model 2</title>
-            </caption>
-            <graphic xlink:href="1234-5678-rctb-45-05-0110-gt031.tif"/>
         </table-wrap>
     </table-wrap-group>
     ...


### PR DESCRIPTION
Fixes #184 inclui elemento <alternatives>, exclui exemplos de tabelas e fórmulas em imagens e inclui exemplo de codificação de equação em LaTeX extraído da JATS em disp-formula.