### PR TITLE
Corrige exemplo de marcação de errata em fn

### DIFF
--- a/docs/source/narr/errata.rst
+++ b/docs/source/narr/errata.rst
@@ -1,4 +1,4 @@
-.. _errata:
+﻿.. _errata:
 
 Errata
 ======
@@ -71,9 +71,9 @@ Exemplo:
     <back>
         ...
         <fn-group>
-            <fn fn-type="other">
-                <title>Erratum</title>
-                <p>Texto da errata</p>
+          <fn fn-type="other">
+            <label>Errata</label>
+              <p>Texto da errata</p>
             </fn>
         </fn-group>
         ...


### PR DESCRIPTION
Fixe #316 corrige exemplo de marcação de errata em nota de rodapé substituindo <title> por <label>.