### PR TITLE
Adiciona regra de envio de imagens em SVG em <alternatives>

### DIFF
--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -1,4 +1,4 @@
-﻿.. _scielo-brasil:
+.. _scielo-brasil:
 
 Regras Específicas para SciELO Brasil
 =====================================
@@ -8,6 +8,7 @@ Para atender aos "Critérios, política e procedimentos para a admissão e a per
 
   * :ref:`elemento-scibrasil-article-id`
   * :ref:`elemento-scibrasil-license`
+  * :ref:`elemento-scibrasil-disp-inline-table`
 
 
 
@@ -91,6 +92,12 @@ A URL da licença deve ser inserida como valor do atributo ``@xlink:href`` de :r
     </article-meta>
     ...
 
-
-
 .. note:: Considera-se a lista de licenças permitidas apenas para :ref:`elemento-article-meta`.
+
+.._elemento-scibrasil-disp-inline-table:
+
+Tabelas e equações codificadas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Os elementos :ref:`elemento-disp-formula`, :ref:`elemento-inline-formula` e :ref:`elemento-table`, que identificam dados de tabelas e equações, devem ser codificados. Adicionalmente, o elemento :ref:`elemento-alternatives` pode ser usado para armazenar a versão em imagem desses elementos na extensão .svg.
+


### PR DESCRIPTION
Fixes #198 estabelece envio de equações e tabelas codificadas e adiciona a opção de envio de imagens para estes elementos em alternatives.