### PR TITLE
Utilizar URL absoluta do *system id*, na declaração de DOCTYPE

### DIFF
--- a/docs/source/tagset/xml-doctype.rst
+++ b/docs/source/tagset/xml-doctype.rst
@@ -9,7 +9,7 @@ Exemplo *JATS versão 1.0*:
 
 .. code-block:: xml
 
-    <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "JATS-journalpublishing1.dtd">
+    <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "http://jats.nlm.nih.gov/publishing/1.0/JATS-journalpublishing1.dtd">
 
 
 


### PR DESCRIPTION
Fixes #489 incluindo a URL no system id.