### PR TITLE
*CDATA* como filho do elemento *name* invalida o doc em relação a JATS

### DIFF
--- a/docs/source/tagset/elemento-product.rst
+++ b/docs/source/tagset/elemento-product.rst
@@ -32,7 +32,7 @@ Exemplo de marcação de ``<product>`` de livro
         <product product-type="book">
             <person-group person-group-type="author">
                 <name>
-                    <surname>ONFRAY</surname>, 
+                    <surname>ONFRAY</surname> 
                     <given-names>Michel</given-names>
                 </name>
             </person-group>. 


### PR DESCRIPTION
Fixes #484 retirado , de name