### PR TITLE
Acrescenta a obrigatoriedade de <contrib-id contrib-id-type="orcid"> em Regras Específicas para SciELO Brasil.

### DIFF
--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -150,5 +150,5 @@ Este elemento em :ref:`elemento-aff` é obrigatório para SciELO Brasil e deve o
 <contrib-id>
 ^^^^^^^^^^^^
 
-Este elemento em :ref:`elemento-contrib` com o atributo ``@contrib-id-type`` e valor "orcid" é obrigatório para SciELO Brasil em pelo menos um dos autores e deve ocorrer uma vez para cada autor.
+Este elemento em :ref:`elemento-contrib` com o atributo ``@contrib-id-type`` e valor "orcid" é obrigatório para SciELO Brasil em pelo menos um dos autores e deve ocorrer uma vez para cada autor. 
 

--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -152,3 +152,5 @@ Este elemento em :ref:`elemento-aff` é obrigatório para SciELO Brasil e deve o
 
 Este elemento em :ref:`elemento-contrib` com o atributo ``@contrib-id-type`` e valor "orcid" é obrigatório para SciELO Brasil em pelo menos um dos autores e deve ocorrer uma vez para cada autor. 
 
+.. note::
+ Uso não é obrigatório para `Errata <http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/latest/narr/errata.html>`_ e `Retratação <http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/latest/narr/retratacao.html>`_

--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -150,7 +150,7 @@ Este elemento em :ref:`elemento-aff` é obrigatório para SciELO Brasil e deve o
 <contrib-id>
 ^^^^^^^^^^^^
 
-Este elemento em :ref:`elemento-contrib` com o atributo ``@contrib-id-type`` e valor "orcid" é obrigatório para SciELO Brasil em pelo menos um dos autores e deve ocorrer uma vez para cada autor. 
+Este elemento em :ref:`elemento-contrib` com o atributo ``@contrib-id-type`` e valor "orcid" é obrigatório para SciELO Brasil em pelo menos um dos autores e deve ocorrer até uma vez para cada autor. 
 
 .. note::
  Uso não é obrigatório para `Errata <http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/latest/narr/errata.html>`_ e `Retratação <http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/latest/narr/retratacao.html>`_

--- a/docs/source/narr/scielo-brasil.rst
+++ b/docs/source/narr/scielo-brasil.rst
@@ -18,7 +18,9 @@ elementos apresentam regras específicas de uso:
   * :ref:`elemento-scibrasil-xref`
   * :ref:`elemento-scibrasil-ref-list`
   * :ref:`elemento-scibrasil-country`
-  * :ref:`elemento-scibrasil-product`    
+  * :ref:`elemento-scibrasil-product`
+  * :ref:`elemento-scibrasil-contrib-id`
+
 
 
 .. _elemento-scibrasil-article-id:
@@ -142,4 +144,11 @@ Este elemento em :ref:`elemento-aff` é obrigatório para SciELO Brasil e deve o
 ^^^^^^^^^
 
 :ref:`elemento-product` contém informações de produto resenhado, mas somente deverá ser utilizado quando :ref:`elemento-article` possuir o atributo ``@article-type="book-review"``.
+
+.. _elemento-scibrasil-contrib-id:
+
+<contrib-id>
+^^^^^^^^^^^^
+
+Este elemento em :ref:`elemento-contrib` com o atributo ``@contrib-id-type`` e valor "orcid" é obrigatório para SciELO Brasil em pelo menos um dos autores e deve ocorrer uma vez para cada autor.
 


### PR DESCRIPTION
#### O que esse PR faz?
Acrescenta a obrigatoriedade de  ```<contrib-id contrib-id-type="orcid">``` em Regras Específicas para SciELO Brasil.

#### Onde a revisão poderia começar?
Após elemento ```<product>```
Acrescentado nota informando que para Errata e Retratação o elemento não é obrigatório, já que errata e retratação não terá autoria.

#### Quais são tickets relevantes?
#634 

