### PR TITLE
Adiciona contribuição dos autores

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -156,6 +156,7 @@ Documentação narrativa
    narr/regra-nomeacao
    narr/tipos-especiais-documentos
    narr/scielo-brasil
+   narr/taxonomia-credit 
 
    glossary
    reference

--- a/docs/source/narr/taxonomia-credit.rst
+++ b/docs/source/narr/taxonomia-credit.rst
@@ -1,6 +1,6 @@
 .. _taxonomia-credit:
 
-Contribuição dos autores (taxonomia CrediT)
+Contribuição dos autores (taxonomia CRediT)
 ===========================================
 
 A taxonomia CRediT proporciona uma maneira de representar informação sobre a 

--- a/docs/source/narr/taxonomia-credit.rst
+++ b/docs/source/narr/taxonomia-credit.rst
@@ -1,0 +1,105 @@
+.. _taxonomia-credit:
+
+Contribuição dos autores (taxonomia CrediT)
+===========================================
+
+A taxonomia CRediT proporciona uma maneira de representar informação sobre a 
+contribuição individual dos autores em documentos XML que seguem a especificação 
+SciELO PS. O propósito da taxonomia CRediT é prover transparência em relação às 
+contribuições dos autores em trabalhos científicos, possibilitando melhorias nos 
+sistemas de atribuição, crédito e prestação de contas.
+
+A tabela a seguir apresenta os termos definidos pela taxonomia CRediT. É 
+importante notar que múltiplos termos podem ser atribuídos a um único contribuidor. 
+Para mais informação acesse https://dictionary.casrai.org/Contributor_Roles.
+
++----------------------------+------------------------------------------------------------------------+
+| Termo                      | URL                                                                    |
++============================+========================================================================+
+| Conceptualization          | https://dictionary.casrai.org/Contributor_Roles/Conceptualization      |
++----------------------------+------------------------------------------------------------------------+
+| Data curation              | https://dictionary.casrai.org/Contributor_Roles/Data_curation          |
++----------------------------+------------------------------------------------------------------------+
+| Formal analysis            | https://dictionary.casrai.org/Contributor_Roles/Formal_analysis        |
++----------------------------+------------------------------------------------------------------------+
+| Funding acquisition        | https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition    |
++----------------------------+------------------------------------------------------------------------+
+| Investigation              | https://dictionary.casrai.org/Contributor_Roles/Investigation          |
++----------------------------+------------------------------------------------------------------------+
+| Methodology                | https://dictionary.casrai.org/Contributor_Roles/Methodology            |
++----------------------------+------------------------------------------------------------------------+
+| Project administration     | https://dictionary.casrai.org/Contributor_Roles/Project_administration |
++----------------------------+------------------------------------------------------------------------+
+| Resources                  | https://dictionary.casrai.org/Contributor_Roles/Resources              |
++----------------------------+------------------------------------------------------------------------+
+| Software                   | https://dictionary.casrai.org/Contributor_Roles/Software               |
++----------------------------+------------------------------------------------------------------------+
+| Supervision                | https://dictionary.casrai.org/Contributor_Roles/Supervision            |
++----------------------------+------------------------------------------------------------------------+
+| Validation                 | https://dictionary.casrai.org/Contributor_Roles/Validation             |
++----------------------------+------------------------------------------------------------------------+
+| Visualization              | https://dictionary.casrai.org/Contributor_Roles/Visualization          |
++----------------------------+------------------------------------------------------------------------+
+| Writing – original draft   | https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft |
++----------------------------+------------------------------------------------------------------------+
+| Writing – review & editing | https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing |
++----------------------------+------------------------------------------------------------------------+
+
+O papel do autor em relação ao artigo deve ser expresso por um termo no elemento 
+`<role>` do XML. Este termo pode ou não ser idêntico aos da tabela acima, desde 
+que a URL correspondente definida pela taxonomia CRediT seja informada no 
+atributo `@content-type`.
+
+Exemplo:
+
+.. code-block:: xml
+
+    ...
+    <contrib-group>
+        <contrib contrib-type="author">
+            <name>
+                <surname>Freitas</surname>
+                <given-names>Ismael Forte</given-names>
+                <suffix>Júnior</suffix>
+            </name>
+            <role content-type="https://dictionary.casrai.org/Contributor_Roles/Conceptualization">Conceptualization</role>
+            <role content-type="https://dictionary.casrai.org/Contributor_Roles/Data_curation">Data curation</role>
+            <role content-type="https://dictionary.casrai.org/Contributor_Roles/Formal_analysis">Formal analysis</role>
+            <role content-type="https://dictionary.casrai.org/Contributor_Roles/Investigation">Investigation</role>
+            <role content-type=" https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft">Writing - original draft</role>
+            <xref ref-type="aff" rid="aff01">1</xref>
+        </contrib>
+        ...
+    </contrib-group>
+    ...
+
+É importante notar que o elemento `<role>` também pode ser utilizado para 
+representar informação não relacionada com a taxonomia CRediT, e nestes casos a 
+decisão sobre como e qual informação incluir é de responsabilidade de cada 
+organização e não há a necessidade de utilizar o atributo `@content-type`.
+
+Exemplo:
+
+.. code-block:: xml
+
+    ...
+    <contrib-group>
+        <contrib contrib-type="author">
+            <name>
+                <surname>Silva</surname>
+                <given-names>Rosângela</given-names>
+            </name>
+            <role content-type="https://dictionary.casrai.org/Contributor_Roles/Conceptualization">Conceitualização</role>
+            <role>Editor de seção</role>
+            <xref ref-type="aff" rid="aff02">2</xref>
+        </contrib>
+        ...
+    </contrib-group>
+    ...
+
+Referências
+
+* JATS4R CRediT Taxonomy Guidelines: https://jats4r.org/credit-taxonomy
+* NISO JATS 1.1: http://jats.nlm.nih.gov/publishing/tag-library/1.1/
+* CASRAI Contributor Roles: https://dictionary.casrai.org/Contributor_Roles
+* CRediT: Contributor Role Taxonomy - Going beyond authorship: https://docs.google.com/document/d/1aJxrQXYHW5U6By3KEAHrx1Iho6ioeh3ohNsRMwsoGPM

--- a/docs/source/tagset/elemento-contrib.rst
+++ b/docs/source/tagset/elemento-contrib.rst
@@ -15,7 +15,10 @@ Atributos obrigatórios:
 
 
 
-Identifica dados individuais, institucionais ou de grupo, de contribuintes do artigo, podendo ser inclusive anônimos. :ref:`elemento-name`, :ref:`elemento-collab`, :ref:`elemento-on-behalf-of`, :ref:`elemento-xref`, :ref:`elemento-role` e ``<anonymous>`` podem ser encontrados neste elemento.
+Identifica dados individuais, institucionais ou de grupo, de contribuintes do 
+artigo, podendo ser inclusive anônimos. :ref:`elemento-name`, :ref:`elemento-collab`, 
+:ref:`elemento-on-behalf-of`, :ref:`elemento-xref`, :ref:`elemento-role` e 
+``<anonymous>`` podem ser encontrados neste elemento.
 
 O atributo ``@contrib-type`` define o tipo de contribuição e pode ter os valores:
 
@@ -42,14 +45,21 @@ Exemplo:
                 <suffix>Júnior</suffix>
             </name>
             <xref ref-type="aff" rid="aff01">1</xref>
+            <role content-type="https://dictionary.casrai.org/Contributor_Roles/Investigation">Pesquisador</role>
         </contrib>
         ...
     </contrib-group>
     ...
 
+
 .. note::
-  * Utilizar *AACR2* - *Código de Catalogação Anglo Americano*, *Registro de ORCID* e/ou *Currículo Lattes* dos autores e avaliar formas de entrada autorizadas para nomes.
-  * Outros tipos de contribuidores como tradutor, ilustrador, assistente de pesquisa, editor etc, devem ser identificados em :ref:`elemento-author-notes`, com :ref:`elemento-fn` e ``@fn-type ="other"``, para editor do artigo ou fascículo usar ``@fn-type ="edited-by"``.
+  * Utilizar *AACR2* - *Código de Catalogação Anglo Americano*, *Registro de ORCID* 
+    e/ou *Currículo Lattes* dos autores e avaliar formas de entrada autorizadas 
+    para nomes.
+  * Outros tipos de contribuidores como tradutor, ilustrador, assistente de 
+    pesquisa, editor etc, devem ser identificados em :ref:`elemento-author-notes`, 
+    com :ref:`elemento-fn` e ``@fn-type ="other"``, para editor do artigo ou 
+    fascículo usar ``@fn-type ="edited-by"``.
+  * Recomenda-se o uso da taxonomia CRediT para representar a função ou papel de
+    cada contribuinte individual. Saiba mais detalhes em :ref:`taxonomia-credit`.
 
-
-.. {"reviewed_on": "20160729", "by": "gandhalf_thewhite@hotmail.com"}

--- a/docs/source/tagset/elemento-role.rst
+++ b/docs/source/tagset/elemento-role.rst
@@ -21,7 +21,11 @@
 
 
 
-``<role>`` (função ou papel) é usado para especificar o tipo de responsabilidade (ou função) do contribuinte do :term:`artigo`.
+``<role>`` (função ou papel) é usado para especificar o tipo de responsabilidade 
+(ou função) do contribuinte do :term:`artigo`. Recomenda-se o uso da taxonomia 
+CRediT para representar esta informação de maneira a prover maior transparência 
+em relação às contribuições dos autores aos trabalhos científicos. Saiba mais 
+detalhes em :ref:`taxonomia-credit`.
 
 Exemplos:
 
@@ -47,7 +51,7 @@ Exemplo de ``<role>`` em ``<contrib>``:
             <suffix>Junior</suffix>
         </name>
         <xref ref-type="aff" rid="aff02">2</xref>
-        <role>Pesquisador</role>
+        <role content-type="https://dictionary.casrai.org/Contributor_Roles/Investigation">Pesquisador</role>
         ...
     </contrib>
     ...

--- a/docs/source/whatsnew-1.10.rst
+++ b/docs/source/whatsnew-1.10.rst
@@ -16,5 +16,8 @@ Documentação
 São as alterações na documentação que não interferem nas regras da especificação.
 
 
+* Adicionada documentação narrativa para descrição da contribuição dos 
+  autores usando a taxonomia CRediT
+  `#821 <https://github.com/scieloorg/scielo_publishing_schema/issues/821>`_.
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona documentação narrativa sobre a representação de informação
sobre contribuição dos autores de acordo com a taxonomia CrediT. O texto
foi baseado na recomendação da JATS4R disponível em https://jats4r.org/credit-taxonomy

#### Onde a revisão poderia começar?
O texto está sendo trabalhado em https://docs.google.com/document/d/1UwHgZc-99cnRlg5lfbLMPAbfWmDLmgMYY1fxgdh9ScI/edit?usp=sharing

### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#821 

### Referências

- JATS4R CRediT Taxonomy Guidelines: https://jats4r.org/credit-taxonomy
- NISO JATS 1.1: http://jats.nlm.nih.gov/publishing/tag-library/1.1/
- CASRAI Contributor Roles: https://dictionary.casrai.org/Contributor_Roles
- CRediT: Contributor Role Taxonomy - Going beyond authorship: https://docs.google.com/document/d/1aJxrQXYHW5U6By3KEAHrx1Iho6ioeh3ohNsRMwsoGPM